### PR TITLE
feat: remove redundant language selectors from User Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,22 @@ Documentation for the [Swarm Bee-js javascript library](https://github.com/ether
 
 You must use **node 14** or above. We recommend [nvm](https://github.com/nvm-sh/nvm).
 
+### Prerequisites
+
+This project requires the bee-js repository to be cloned as a git submodule.
+
+You can fetch it by cloning the entire repository with the following command:
+
+```
+$ git clone --recurse-submodules https://github.com/ethersphere/bee-js.git
+```
+
+Or optionally fetch the submodule after cloning with the following command:
+
+```
+$ git submodule update --init
+```
+
 ### Installation
 
 ```

--- a/docs/user-documentation/getting-started.md
+++ b/docs/user-documentation/getting-started.md
@@ -43,33 +43,11 @@ yarn add @ethersphere/bee-js --save
 After that you need to import the Bee class and create a bee instance connecting to your Bee node (here we assume it runs on localhost on default port).
 Be aware, if you will pass invalid URL the constructor will throw an exception!
 
-
-<Tabs
-  groupId="lang_preferrence"
-  defaultValue="ts"
-  values={[
-    {label: 'TypeScript', value: 'ts'},
-    {label: 'JavaScript', value: 'js'},
-  ]}>
-  <TabItem value="ts">
-
-```ts
-import { Bee } from "@ethersphere/bee-js"
-
-const bee = new Bee('http://localhost:1633')
-```
-
-  </TabItem>
-  <TabItem value="js">
-
 ```js
 import { Bee } from "@ethersphere/bee-js"
 
 const bee = new Bee('http://localhost:1633')
 ```
-
-  </TabItem>
-</Tabs>
 
 That’s it! now you can use the `bee` object.
 

--- a/docs/user-documentation/pss.md
+++ b/docs/user-documentation/pss.md
@@ -174,8 +174,8 @@ subscription.cancel()
 
 ```js
 const handler = {
-  onMessage: (message: Data) => {console.log(message.text())},
-  onError: (error: BeeError) => {console.log(error)}
+  onMessage: (message) => {console.log(message.text())},
+  onError: (error) => {console.log(error)}
 }
 
 // Subscribe

--- a/docs/user-documentation/track-upload.md
+++ b/docs/user-documentation/track-upload.md
@@ -45,57 +45,14 @@ If you are using a node that is in Gateway mode then this operation is not allow
 
 Creating a tag is easy. Just use the `createTag` function.
 
-<Tabs
-  groupId="lang_preferrence"
-  defaultValue="ts"
-  values={[
-    {label: 'TypeScript', value: 'ts'},
-    {label: 'JavaScript', value: 'js'},
-  ]}>
-  <TabItem value="ts">
-
-```ts
-const tag = await bee.createTag()
-```
-
-  </TabItem>
-  <TabItem value="js">
-
 ```js
 const tag = await bee.createTag()
 ```
-
-  </TabItem>
-</Tabs>
 
 ## Upload with tag
 
 You can then use the tag when uploading data, by providing it in the options arguments for each of these methods.
 
-<Tabs
-  groupId="lang_preferrence"
-  defaultValue="ts"
-  values={[
-    {label: 'TypeScript', value: 'ts'},
-    {label: 'JavaScript', value: 'js'},
-  ]}>
-  <TabItem value="ts">
-
-```ts
-const postageBatchId = getOrCreatePostageBatch()
-
-await bee.uploadData(postageBatchId, "Bee is awesome!", { tag })
-// OR
-await bee.uploadFile(postageBatchId, file, "foo.txt", { tag })
-// OR
-await bee.uploadFiles(postageBatchId, files, { tag })
-// OR
-await bee.uploadFilesFromDirectory(postageBatchId, "./", { tag })
-```
-
-  </TabItem>
-  <TabItem value="js">
-
 ```js
 const postageBatchId = getOrCreatePostageBatch()
 
@@ -107,9 +64,6 @@ await bee.uploadFiles(postageBatchId, files, { tag })
 // OR
 await bee.uploadFilesFromDirectory(postageBatchId, "./", { tag })
 ```
-
-  </TabItem>
-</Tabs>
 
 ## Retrieve tag
 
@@ -119,30 +73,8 @@ If you are using a node that is in Gateway mode then this operation is not allow
 
 Each time you want to check the upload status, you can use the `retrieveTag` function.
 
-
-<Tabs
-  groupId="lang_preferrence"
-  defaultValue="ts"
-  values={[
-    {label: 'TypeScript', value: 'ts'},
-    {label: 'JavaScript', value: 'js'},
-  ]}>
-  <TabItem value="ts">
-
-```ts
-const updatedTag = await bee.retrieveTag(tag)
-// OR
-const updatedTag = await bee.retrieveTag(tag.uid)
-```
-
-  </TabItem>
-  <TabItem value="js">
-
 ```js
 const updatedTag = await bee.retrieveTag(tag)
 // OR
 const updatedTag = await bee.retrieveTag(tag.uid)
 ```
-
-  </TabItem>
-</Tabs>

--- a/docs/user-documentation/upload-download.md
+++ b/docs/user-documentation/upload-download.md
@@ -30,31 +30,6 @@ When you download data the return type is [`Data`](../api/interfaces/data.md) in
  - `hex()` that converts the bytes into **non-prefixed** hex string
  - `json()` that converts the bytes into JSON object
 
-<Tabs
-  groupId="lang_preferrence"
-  defaultValue="ts"
-  values={[
-    {label: 'TypeScript', value: 'ts'},
-    {label: 'JavaScript', value: 'js'},
-  ]}>
-  <TabItem value="ts">
-
-```ts
-const postageBatchId = await bee.createPostageBatch("100", 17)
-const result = await bee.uploadData(postageBatchId, "Bee is awesome!")
-
-// prints Swarm hash of the file with which it can be retrieved
-// here it is fd79d5e0ebd8407e422f53ce1d7c4c41ebf403be55143900f8d1490560294780
-console.log(result.reference) 
-
-const retrievedData = await bee.downloadData(result.reference)
-
-console.log(retrievedData.text()) // prints 'Bee is awesome!'
-```
-
-  </TabItem>
-  <TabItem value="js">
-
 ```js
 const postageBatchId = await bee.createPostageBatch("100", 17)
 const result = await bee.uploadData(postageBatchId, "Bee is awesome!")
@@ -67,9 +42,6 @@ const retrievedData = await bee.downloadData(result.reference)
 
 console.log(retrievedData.text()) // prints 'Bee is awesome!'
 ```
-
-  </TabItem>
-</Tabs>
 
 :::info Tip
 Swarm reference or hash is a 64 characters long hex string which is the address of the uploaded data, file or directory.
@@ -79,28 +51,6 @@ Swarm reference or hash is a 64 characters long hex string which is the address 
 
 You can also upload files and include a filename. When you download the file, `bee-js` will return additional information like `contentType` or `name` of the file.
 
-<Tabs
-  groupId="lang_preferrence"
-  defaultValue="ts"
-  values={[
-    {label: 'TypeScript', value: 'ts'},
-    {label: 'JavaScript', value: 'js'},
-  ]}>
-  <TabItem value="ts">
-
-```ts
-const postageBatchId = await bee.createPostageBatch("100", 17)
-const result = await bee.uploadFile(postageBatchId, "Bee is awesome!", "textfile.txt")
-const retrievedFile = await bee.downloadFile(result.reference)
-
-console.log(retrievedFile.name) // prints 'textfile.txt'
-console.log(retrievedFile.contentType) // prints 'application/octet-stream'
-console.log(retrievedFile.data.text()) // prints 'Bee is awesome!'
-```
-
-  </TabItem>
-  <TabItem value="js">
-
 ```js
 const postageBatchId = await bee.createPostageBatch("100", 17)
 const result = await bee.uploadFile(postageBatchId, "Bee is awesome!", "textfile.txt")
@@ -110,36 +60,9 @@ console.log(retrievedFile.name) // prints 'textfile.txt'
 console.log(retrievedFile.contentType) // prints 'application/octet-stream'
 console.log(retrievedFile.data.text()) // prints 'Bee is awesome!'
 ```
-
-  </TabItem>
-</Tabs>
 
 In browsers, you can upload directly `File` type. The filename is taken from the file object itself, but can be overwritten through the second argument of the `uploadFile` function (see the [API docs](../api/classes/bee.md#uploadfile))
 
-<Tabs
-  groupId="lang_preferrence"
-  defaultValue="ts"
-  values={[
-    {label: 'TypeScript', value: 'ts'},
-    {label: 'JavaScript', value: 'js'},
-  ]}>
-  <TabItem value="ts">
-
-```ts
-const file = new File(["foo"], "foo.txt", { type: "text/plain" })
-
-const postageBatchId = await bee.createPostageBatch("100", 17)
-const result = await bee.uploadFile(postageBatchId, file)
-const retrievedFile = await bee.downloadFile(result.reference)
-
-console.log(retrievedFile.name) // prints 'foo.txt'
-console.log(retrievedFile.contentType) // prints 'text/plain'
-console.log(retrievedFile.data.text()) // prints 'foo'
-```
-
-  </TabItem>
-  <TabItem value="js">
-
 ```js
 const file = new File(["foo"], "foo.txt", { type: "text/plain" })
 
@@ -151,40 +74,11 @@ console.log(retrievedFile.name) // prints 'foo.txt'
 console.log(retrievedFile.contentType) // prints 'text/plain'
 console.log(retrievedFile.data.text()) // prints 'foo'
 ```
-
-  </TabItem>
-</Tabs>
 
 ### Files and Directories
 
 The last supported mode is upload of files and directories. In browsers, you can easily upload an array of `File` comming from your form directly as well as [`FileList`](https://developer.mozilla.org/en-US/docs/Web/API/FileList). If the files uploaded through `uploadFiles` have a relative path, they are added relative to this filepath. Otherwise, the whole structure is flattened into single directory.
 
-<Tabs
-  groupId="lang_preferrence"
-  defaultValue="ts"
-  values={[
-    {label: 'TypeScript', value: 'ts'},
-    {label: 'JavaScript', value: 'js'},
-  ]}>
-  <TabItem value="ts">
-
-```ts
-const foo = new File(["foo"], "foo.txt", { type: "text/plain" })
-const bar = new File(["bar"], "bar.txt", { type: "text/plain" })
-
-const postageBatchId = await bee.createPostageBatch("100", 17)
-const result = await bee.uploadFiles(postageBatchId, [ foo, bar ]) // upload
-
-const rFoo = await bee.downloadFile(result.reference, './foo.txt') // download foo
-const rBar = await bee.downloadFile(result.reference, './bar.txt') // download bar
-
-console.log(rFoo.data.text()) // prints 'foo'
-console.log(rBar.data.text()) // prints 'bar'
-```
-
-  </TabItem>
-  <TabItem value="js">
-
 ```js
 const foo = new File(["foo"], "foo.txt", { type: "text/plain" })
 const bar = new File(["bar"], "bar.txt", { type: "text/plain" })
@@ -198,9 +92,6 @@ const rBar = await bee.downloadFile(result.reference, './bar.txt') // download b
 console.log(rFoo.data.text()) // prints 'foo'
 console.log(rBar.data.text()) // prints 'bar'
 ```
-
-  </TabItem>
-</Tabs>
 
 In nodejs, you may utilise the `uploadFilesFromDirectory` function, which takes directory path as input and upload all files in that directory. Lets assum we have following data structure:
 
@@ -211,16 +102,7 @@ In nodejs, you may utilise the `uploadFilesFromDirectory` function, which takes 
 |   +-- bar.txt
 ```
 
-<Tabs
-  groupId="lang_preferrence"
-  defaultValue="ts"
-  values={[
-    {label: 'TypeScript', value: 'ts'},
-    {label: 'JavaScript', value: 'js'},
-  ]}>
-  <TabItem value="ts">
-
-```ts
+```js
 const postageBatchId = await bee.createPostageBatch("100", 17)
 
 const result = await bee.uploadFilesFromDirectory(postageBatchId, './') // upload recursively current folder
@@ -231,24 +113,6 @@ const rBar = await bee.downloadFile(result.reference, './dir/bar.txt') // downlo
 console.log(rFoo.data.text()) // prints 'foo'
 console.log(rBar.data.text()) // prints 'bar'
 ```
-
-  </TabItem>
-  <TabItem value="js">
-
-```js
-const postageBatchId = await bee.createPostageBatch("100", 17)
-
-const hash = await bee.uploadFilesFromDirectory(postageBatchId, './') // upload recursively current folder
-
-const rFoo = await bee.downloadFile(result.reference, './foo.txt') // download foo
-const rBar = await bee.downloadFile(result.reference, './dir/bar.txt') // download bar
-
-console.log(rFoo.data.text()) // prints 'foo'
-console.log(rBar.data.text()) // prints 'bar'
-```
-
-  </TabItem>
-</Tabs>
 
 ## Retrieve file from node or gateway
 


### PR DESCRIPTION
**Add information to README about bee-js submodule requirement**

**Remove redundant language selectors from User Documentation** 

> In most cases the Typescript / Javascript codeblock language selectors
shared the same exact code snippets.
>
> For these cases, the redundant language selector control and duplicate
code snippets have been removed.