### PR TITLE
revert: ci: trigger pr previews on new commits (#108)

### DIFF
--- a/.github/workflows/update-api-docs.yaml
+++ b/.github/workflows/update-api-docs.yaml
@@ -14,7 +14,6 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
-          persist-credentials: false
 
       - name: Use Node.js 16
         uses: actions/setup-node@v1


### PR DESCRIPTION
This started to fail the Update Action because it was not possible to update the Bee-js submodule thanks to that :-(