### PR TITLE
fix: update code examples for bee-js v10/v11 API changes

### DIFF
--- a/docs/documentation/buying-storage.md
+++ b/docs/documentation/buying-storage.md
@@ -108,7 +108,7 @@ import { Bee, Size } from "@ethersphere/bee-js"
 const bee = new Bee('http://localhost:1633')
 
 // Request all local postage batches
-const batches = await bee.getAllPostageBatch()
+const batches = await bee.getPostageBatches()
 
 const batchId = batches[0].batchID
 
@@ -133,7 +133,7 @@ import { Bee, Size } from "@ethersphere/bee-js"
 const bee = new Bee('http://localhost:1633')
 
 // Request all local postage batches
-const batches = await bee.getAllPostageBatch()
+const batches = await bee.getPostageBatches()
 
 // Print results to the terminal
 console.log(batches)
@@ -195,7 +195,7 @@ import { Bee, Duration } from "@ethersphere/bee-js"
 const bee = new Bee('http://localhost:1633')
 
 // Request all local postage batches
-const batches = await bee.getAllPostageBatch()
+const batches = await bee.getPostageBatches()
 
 // Select the batch ID of the first batch in the list
 const batchId = batches[0].batchID
@@ -221,7 +221,7 @@ import { Bee, Duration } from "@ethersphere/bee-js"
 const bee = new Bee('http://localhost:1633')
 
 // Request all local postage batches
-const batches = await bee.getAllPostageBatch()
+const batches = await bee.getPostageBatches()
 
 // Select the batch ID of the first batch in the list
 const batchId = batches[0].batchID
@@ -281,7 +281,7 @@ import { Bee, Size, Duration } from "@ethersphere/bee-js"
 const bee = new Bee('http://localhost:1633')
 
 // Request all local postage batches
-const batches = await bee.getAllPostageBatch()
+const batches = await bee.getPostageBatches()
 
 // Choose a batch to extend
 const batchId = batches[0].batchID
@@ -312,7 +312,7 @@ If you're happy with the cost, you can then proceed to extend the **size** and *
 
 ### Checking Batch Status
 
-You can check the status of purchased batches using the `bee.getAllPostageBatch` method:
+You can check the status of purchased batches using the `bee.getPostageBatches` method:
 
 
 ```javascript
@@ -321,7 +321,7 @@ import { Bee } from "@ethersphere/bee-js"
 const bee = new Bee('http://localhost:1633')
 
 // Request all local postage batches
-const batches = await bee.getAllPostageBatch()
+const batches = await bee.getPostageBatches()
 
 // Print results to the terminal
 console.log(batches) 
@@ -382,7 +382,7 @@ import { Bee } from '@ethersphere/bee-js'
 const bee = new Bee('http://localhost:1633')
 
 export async function getBatch(bee, criteriaFn) {
-  const batches = await bee.getAllPostageBatch()
+  const batches = await bee.getPostageBatches()
   const matchingBatch = batches.find(criteriaFn)
 
   if (!matchingBatch) {
@@ -409,7 +409,7 @@ function isUsableWithFreeSpace(batch) {
 const batchId = getBatch(bee, isUsableWithFreeSpace)
 ```
 
-If you need a batch with specific characteristics (such as a batch with at least 10 GB remaining space or a mutable batch), then you should [inspect](/docs/storage/#checking-batch-status) your postage batches' status using `bee.getAllPostageBatch` in order to check if a batch with your desired characteristics exists and return its id.
+If you need a batch with specific characteristics (such as a batch with at least 10 GB remaining space or a mutable batch), then you should [inspect](/docs/storage/#checking-batch-status) your postage batches' status using `bee.getPostageBatches` in order to check if a batch with your desired characteristics exists and return its id.
 
 ### Batch Size Breakpoints
 
@@ -473,7 +473,7 @@ The class also includes three *instance* methods for getting the value from an e
 
 sizeB.toBytes()          // → 5000000000
 sizeB.toGigabytes()      // → 5
-sizeB.toFormattedString() // → '5.00 GB'
+sizeB.toFormattedString() // → '5.000 GB'
 ```
 
 

--- a/docs/documentation/chequebook.md
+++ b/docs/documentation/chequebook.md
@@ -25,9 +25,13 @@ To use the example scripts below, you need:
 Deposits a specified amount of BZZ into the chequebook from your node wallet. This ensures that your node can issue cheques for transactions.
 
 ```javascript
-const amount = new BZZ.fromDecimalString('1') // Deposit 1 BZZ
+import { Bee, BZZ } from '@ethersphere/bee-js'
 
-const transactionHash = await bee.depositTokens(amount)
+const bee = new Bee('http://localhost:1633')
+
+const amount = BZZ.fromDecimalString('1') // Deposit 1 BZZ
+
+const transactionHash = await bee.depositBZZToChequebook(amount)
 console.log('Deposit transaction hash:', transactionHash.toHex())
 ```
 
@@ -56,9 +60,13 @@ Chequebook Balance: {
 Withdraws a specified amount of BZZ from the chequebook to the node wallet. You may need to withdraw if you want to transfer BZZ to another account or for other uses.
 
 ```javascript
-const amountToWithdraw = new BZZ.fromDecimalString('1') // Withdraw 1 BZZ
+import { Bee, BZZ } from '@ethersphere/bee-js'
 
-const withdrawalHash = await bee.withdrawTokens(amountToWithdraw)
+const bee = new Bee('http://localhost:1633')
+
+const amountToWithdraw = BZZ.fromDecimalString('1') // Withdraw 1 BZZ
+
+const withdrawalHash = await bee.withdrawBZZFromChequebook(amountToWithdraw)
 console.log('Withdraw transaction hash:', withdrawalHash.toHex())
 ```
 

--- a/docs/documentation/gsoc.md
+++ b/docs/documentation/gsoc.md
@@ -93,10 +93,10 @@ The `Overlay` should be saved and shared with sender nodes.
 This must be run on a full node. It mines a key that lands within its own neighborhood and starts listening.
 
 ```js
-import { Bee, Identifier, NULL_IDENTIFIER } from '@ethersphere/bee-js'
+import { Bee, NULL_IDENTIFIER } from '@ethersphere/bee-js'
 
 const bee = new Bee('http://localhost:1633')
-const identifier = Identifier.fromString(NULL_IDENTIFIER)
+const identifier = NULL_IDENTIFIER
 
 async function listen() {
   const { overlay } = await bee.getNodeAddresses()
@@ -109,6 +109,7 @@ async function listen() {
     // A callback function is used to handle incoming updates - you can include your application logic here
     onMessage: message => console.log('Received:', message.toUtf8()),
     onError: error => console.error('Subscription error:', error),
+    onClose: () => console.log('Subscription closed.'),
   })
 
   console.log('Listening for GSOC updates...')
@@ -122,12 +123,12 @@ listen()
 The sending node must have a ***usable postage batch id*** and also know the ***target overlay address*** and ***identifier*** in order to send a message: 
 
 ```js
-import { Bee, Identifier, NULL_IDENTIFIER } from '@ethersphere/bee-js'
+import { Bee, NULL_IDENTIFIER } from '@ethersphere/bee-js'
 
 const bee = new Bee('http://localhost:1643')
 
 // The identifier is initialized using the same data as the receiving node
-const identifier = Identifier.fromString(NULL_IDENTIFIER)
+const identifier = NULL_IDENTIFIER
 const batchId = '6c84b6d3f5273b969c3df875cde7ccd9920f5580122929aedaf440bfe4484405'
 
 const recipientOverlay = '1e2054bec3e681aeb0b365a1f9a574a03782176bd3ec0bcf810ebcaf551e4070'

--- a/docs/documentation/overview.md
+++ b/docs/documentation/overview.md
@@ -125,8 +125,8 @@ Each `bee-js` method corresponds to a particular endpoint from the API. The char
 | `getLastChequesForPeer`              | `GET /chequebook/cheque/:peer` [🔗](https://docs.ethswarm.org/api/#tag/Chequebook/paths/~1chequebook~1cheque~1%7Bpeer-id%7D/get)                         | ❌✅✅   |
 | `getLastCashoutAction`               | `GET /chequebook/cashout/:peer` [🔗](https://docs.ethswarm.org/api/#tag/Chequebook/paths/~1chequebook~1cashout~1%7Bpeer-id%7D/get)                       | ❌✅✅   |
 | `cashoutLastCheque`                  | `POST /chequebook/cashout/:peer` [🔗](https://docs.ethswarm.org/api/#tag/Chequebook/paths/~1chequebook~1cashout~1%7Bpeer-id%7D/post)                     | ❌✅✅   |
-| `depositTokens`                      | `POST /chequebook/deposit` [🔗](https://docs.ethswarm.org/api/#tag/Chequebook/paths/~1chequebook~1deposit/post)                                          | ❌✅✅   |
-| `withdrawTokens`                     | `POST /chequebook/withdraw` [🔗](https://docs.ethswarm.org/api/#tag/Chequebook/paths/~1chequebook~1withdraw/post)                                        | ❌✅✅   |
+| `depositBZZToChequebook`             | `POST /chequebook/deposit` [🔗](https://docs.ethswarm.org/api/#tag/Chequebook/paths/~1chequebook~1deposit/post)                                          | ❌✅✅   |
+| `withdrawBZZFromChequebook`          | `POST /chequebook/withdraw` [🔗](https://docs.ethswarm.org/api/#tag/Chequebook/paths/~1chequebook~1withdraw/post)                                        | ❌✅✅   |
 | `getAllPendingTransactions`          | `GET /transactions` [🔗](https://docs.ethswarm.org/api/#tag/Transaction/paths/~1transactions/get)                                                        | ❌✅✅   |
 | `getPendingTransaction`              | `GET /transactions/:id` [🔗](https://docs.ethswarm.org/api/#tag/Transaction/paths/~1transactions~1%7BtxHash%7D/get)                                      | ❌✅✅   |
 | `rebroadcastTransaction`             | `POST /transactions/:id` [🔗](https://docs.ethswarm.org/api/#tag/Transaction/paths/~1transactions~1%7BtxHash%7D/post)                                    | ❌✅✅   |
@@ -148,7 +148,7 @@ Each `bee-js` method corresponds to a particular endpoint from the API. The char
 | `pssSend`                            | `POST /pss/send/:topic/:target` [🔗](https://docs.ethswarm.org/api/#tag/Postal-Service-for-Swarm/paths/~1pss~1send~1%7Btopic%7D~1%7Btargets%7D/post)     | ❌✅✅   |
 | `pssSubscribe` _Websocket_           | `GET /pss/subscribe/:topic` [🔗](https://docs.ethswarm.org/api/#tag/Postal-Service-for-Swarm/paths/~1pss~1subscribe~1%7Btopic%7D/get)                    | ❌❌✅   |
 | `pssReceive`                         | `GET /pss/subscribe/:topic` [🔗](https://docs.ethswarm.org/api/#tag/Postal-Service-for-Swarm/paths/~1pss~1subscribe~1%7Btopic%7D/get)                    | ❌❌✅   |
-| `getAllPostageBatch`                 | `GET /stamps` [🔗](https://docs.ethswarm.org/api/#tag/Postage-Stamps/paths/~1stamps/get)                                                                 | ❌✅✅   |
+| `getPostageBatches`                 | `GET /stamps` [🔗](https://docs.ethswarm.org/api/#tag/Postage-Stamps/paths/~1stamps/get)                                                                 | ❌✅✅   |
 | `getGlobalPostageBatches`            | `GET /batches` [🔗](https://docs.ethswarm.org/api/#tag/Postage-Stamps/paths/~1batches/get)                                                               | ❌✅✅   |
 | `getPostageBatch`                    | `GET /stamps/:batchId` [🔗](https://docs.ethswarm.org/api/#tag/Postage-Stamps/paths/~1stamps~1%7Bbatch_id%7D/get)                                        | ❌✅✅   |
 | `getPostageBatchBuckets`             | `GET /stamps/:batchId/buckets` [🔗](https://docs.ethswarm.org/api/#tag/Postage-Stamps/paths/~1stamps~1%7Bbatch_id%7D~1buckets/get)                       | ❌✅✅   |

--- a/docs/documentation/pss.md
+++ b/docs/documentation/pss.md
@@ -87,6 +87,7 @@ console.log('Subscribing to topic:', topic.toHex())
 bee.pssSubscribe(topic, {
   onMessage: msg => console.log('Received via subscription:', msg.toUtf8()),
   onError: err => console.error('Subscription error:', err.message),
+  onClose: () => console.log('Subscription closed.'),
 })
 
 // One-time receive (3 hour timeout)

--- a/docs/documentation/soc-and-feeds.md
+++ b/docs/documentation/soc-and-feeds.md
@@ -26,15 +26,15 @@ Interactions with SOC and feeds require the following:
 You can use the `PrivateKey` class to generate a dedicated publisher key for signing SOC and feed updates:
 
 ```js
-const crypto = require('crypto');
-const { PrivateKey } = require('@ethersphere/bee-js');
+import crypto from 'node:crypto'
+import { PrivateKey } from '@ethersphere/bee-js'
 
 // Generate 32 random bytes and construct a private key
-const hexKey = '0x' + crypto.randomBytes(32).toString('hex');
-const privateKey = new PrivateKey(hexKey);
+const hexKey = '0x' + crypto.randomBytes(32).toString('hex')
+const privateKey = new PrivateKey(hexKey)
 
-console.log('Private key:', privateKey.toHex());
-console.log('Public address:', privateKey.publicKey().address().toHex());
+console.log('Private key:', privateKey.toHex())
+console.log('Public address:', privateKey.publicKey().address().toHex())
 ````
 
 Example output:
@@ -152,7 +152,7 @@ Unlike uploads using content addressed chunks which are retrieved by their Swarm
 :::
 
 ```js
-import { Bee, Size, NULL_IDENTIFIER } from "@ethersphere/bee-js"
+import { Bee, NULL_IDENTIFIER } from "@ethersphere/bee-js"
 
 // Initialize Bee client pointing to the Swarm node
 const bee = new Bee('http://localhost:1633')


### PR DESCRIPTION
## Summary

This PR corrects code examples in the bee-js documentation to align with the current bee-js API (v10.x / v11.x). The docs had not been updated to reflect several breaking changes introduced over the last 6 months.

## Changes

### `chequebook.md`
- **Fix:** `new BZZ.fromDecimalString('1')` -> `BZZ.fromDecimalString('1')` (BZZ is a static factory, not a constructor)
- **Fix:** Replace deprecated `depositTokens()` with `depositBZZToChequebook()`
- **Fix:** Replace deprecated `withdrawTokens()` with `withdrawBZZFromChequebook()`
- **Fix:** Add missing `import { Bee, BZZ } from '@ethersphere/bee-js'` to the deposit and withdraw snippets

### `buying-storage.md`
- **Fix:** Replace all occurrences of deprecated `getAllPostageBatch()` with `getPostageBatches()` (marked for removal in June 2025)
- **Fix:** Correct `Size.toFormattedString()` comment: returns '5.000 GB' not '5.00 GB'

### `pss.md`
- **Fix:** Add required `onClose` handler to `pssSubscribe()` — became a required field in v10.0.0 (#1075). Without it, calling `pssSubscribe` throws `Error: Expected function for onClose, got: undefined`.

### `gsoc.md`
- **Fix:** `Identifier.fromString(NULL_IDENTIFIER)` -> `const identifier = NULL_IDENTIFIER`. `NULL_IDENTIFIER` is a Uint8Array of 32 zero bytes. Passing it to `Identifier.fromString()` hashes its string representation via keccak256, producing a completely different non-zero identifier — the listener and sender would never match.
- **Fix:** Add required `onClose` handler to `gsocSubscribe()` (same breaking change as PSS above)
- **Fix:** Remove unnecessary `Identifier` import from the updated examples

### `soc-and-feeds.md`
- **Fix:** Convert CommonJS `require()` syntax to ESM `import` syntax in the PrivateKey generation tip (all other examples in the file use ESM)
- **Fix:** Remove unused `Size` import from the SOC read example

### `overview.md`
- **Fix:** Update deprecated method names in the API method table

## Testing

All code examples were verified against bee-js v11.1.1. Key failures reproduced before fixing:
- `new BZZ.fromDecimalString('1')` throws `TypeError: BZZ.fromDecimalString is not a constructor`
- `pssSubscribe({onMessage, onError})` without `onClose` throws `Error: Expected function for onClose, got: undefined`
- `gsocSubscribe({onMessage, onError})` without `onClose` throws `Error: Expected function for onClose, got: undefined`
- `Identifier.fromString(NULL_IDENTIFIER)` produces wrong identifier (keccak of the Uint8Array string representation instead of zero bytes)
